### PR TITLE
fix LMK finish state

### DIFF
--- a/hardware/static/js/hw.js
+++ b/hardware/static/js/hw.js
@@ -48,6 +48,7 @@ let hw = (()=>{
         let msg = msg_in || ""
         let title = title_in || "HackathonAssistant"
         let closeIn = time || 10000
+        var icon = icon || window.location.origin + "/static/favicon.png"
         let notification = new Notification(title, {
             body: msg,
             icon: icon


### PR DESCRIPTION
## What this PR does / Why we need it
This PR fixes issue 11. Issue 12 will be marked as wont-fix because it's not supported by firefox and (apparently) some desktop implementations (tested on i3 Manjaro chrome).
Correctly clears the timer when not querying items anymore. When an item becomes available, the button will display "REQUEST" without needing a refresh

## Which issue(s) this PR fixes (optional) 
Fixes #11 

## Some questions
- [x] I have read the contributing guidelines
- [x] I abide by this repository Code of Conduct
- [x] I understand that my PR won't be merged until Travis gives a "green light"
